### PR TITLE
Hotfix/image delete fix

### DIFF
--- a/backend/src/controllers/sectionImages.js
+++ b/backend/src/controllers/sectionImages.js
@@ -4,7 +4,7 @@ import * as url from "url";
 import multer from 'multer';
 import * as path from "path";
 
-const imageFolderDir = 'images/';
+const imageFolderDir = './images/';
 
 //Finds the path of an existing file based on the section id, or null if no image is present.
 async function getImagePath(id){

--- a/backend/src/middleware/minio.js
+++ b/backend/src/middleware/minio.js
@@ -7,28 +7,41 @@ function getFileName(){
     return new Date().toJSON().slice(0,19).replaceAll(/[-:]/g, '');
 }
 
-const client = new minio.Client({
-    port: parseInt(process.env.MINIO_PORT),
-    endPoint: process.env.MINIO_ENDPOINT,
-    accessKey: process.env.MINIO_ACCESS_KEY,
-    secretKey: process.env.MINIO_SECRET_KEY,
-    useSSL: false //TODO this obviously shouldn't be false in production.
-});
-
 const bucket = "blog-images";
-const storage = new MinioStorageEngine(client, bucket, {
-    bucket: {
-        init: true,
-        versioning: false,
-        forceDelete: false
-    },
-    path : '',
-    object: {
-        name: (req, file) => {
-            return `${getFileName()}${path.extname(file.originalname)}`;
-        }
-    },
-});
+function getMinioUrl(filename){
+    return `http://${process.env.MINIO_ENDPOINT}:${process.env.MINIO_PORT}/${bucket}/${filename}`;
+}
+
+let client;
+let storage;
+try {
+    client = new minio.Client({
+        port: parseInt(process.env.MINIO_PORT),
+        endPoint: process.env.MINIO_ENDPOINT,
+        accessKey: process.env.MINIO_ACCESS_KEY,
+        secretKey: process.env.MINIO_SECRET_KEY,
+        useSSL: false //TODO this obviously shouldn't be false in production.
+    });
+    //Verifying connection
+    await client.listBuckets();
+    console.log(`Connected to minio at ${getMinioUrl()}`);
+
+    storage = new MinioStorageEngine(client, bucket, {
+        bucket: {
+            init: true,
+            versioning: false,
+            forceDelete: false
+        },
+        path : '',
+        object: {
+            name: (req, file) => {
+                return `${getFileName()}${path.extname(file.originalname)}`;
+            }
+        },
+    });
+} catch {
+    console.error(`Error when connecting to minio at ${getMinioUrl()}.`);
+}
 
 export function uploadImageMiddleware(req, res, next){
     multer({storage}).single('image')(req, res, err => {
@@ -39,7 +52,7 @@ export function uploadImageMiddleware(req, res, next){
 
         if (req.file){
             //TODO this only works for localhost I think
-            req.body.imageUrl = `http://${process.env.MINIO_ENDPOINT}:${process.env.MINIO_PORT}/${bucket}/${req.file.filename}`;
+            req.body.imageUrl = getMinioUrl(req.file.filename);
         }
         return next();
     });


### PR DESCRIPTION
Static landing page images were not getting deleted in the backend if the file extension was different.
Also made it so the backend doesn't die completly if minio isn't setup to make debugging unrelated stuff easier.